### PR TITLE
Convert entity tables to factories

### DIFF
--- a/entities/README.md
+++ b/entities/README.md
@@ -25,6 +25,10 @@ Given a `nil` value instead of a table, the entity won't be given a body.
 - friction (number) Set the contact sliding friction. [[1](https://love2d.org/wiki/Fixture:setFriction)]
 - mask (number = 0) Set which fixture categories are filtered from collision. Add the categories together you want the fixture to ignore colliding with and subtract that number from `65535`. For instance, a player doesn't collide with players or player bullets so the formula for that would be `65535 - 1 - 2`.
 
+### gravitational_mass (number = 0)
+
+Mass for calculating gravity between two entities
+
 ### shape (table)
 
 The shape is attached to the fixture and determines the entity's hitbox.
@@ -46,9 +50,3 @@ A `nil` value means no sprite will be registered.
 - offset_y (number = offset_x) The y-axis pixel offset. This will match the offset_x unless specified.
 - scale_x (number = 1) The x-axis scaling of the sprite.
 - scale_y (number = 1) The y-axis scaling of the sprite.
-
-### Optional Values
-
-Other traits assignable to entities that are optional
-
-- gravitational_mass (number) What mass to use when calculating gravity between two entities

--- a/entities/planet.lua
+++ b/entities/planet.lua
@@ -1,18 +1,20 @@
-return {
-    body = {
-        mass = 75,
-        type = 'static'
-    },
-    fixture = {
-        category = 1,
-        density = 10,
-        friction = 0,
-        mask = 65535
-    },
-    shape = {
-        radius = 100,
-        type = 'circle',
-        visible = true
-    },
-    gravitational_mass = 5
-}
+return function(props)
+    return {
+        body = {
+            mass = 75,
+            type = 'static'
+        },
+        fixture = {
+            category = 1,
+            density = 10,
+            friction = 0,
+            mask = 65535
+        },
+        gravitational_mass = 5,
+        shape = {
+            radius = props.radius or 100,
+            type = 'circle',
+            visible = true
+        }
+    }
+end

--- a/entities/player.lua
+++ b/entities/player.lua
@@ -1,28 +1,30 @@
-return {
-    body = {
-        mass = 1
-    },
-    fixture = {
-        category = 1,
-        density = 10,
-        friction = 0,
-        mask = 65535
-    },
-    isControlled = true,
-    shape = {
-        points = {
-            0, -25,
-            -25, 2,
-            -25, 25,
-            25, 2,
-            25, 25
+return function()
+    return {
+        body = {
+            mass = 1
         },
-        type = 'polygon'
-    },
-    spritesheet = {
-        image = 'spaceship',
-        offset_x = 12.5,
-        scale_x = 2
-    },
-    gravitational_mass = 1
-}
+        fixture = {
+            category = 1,
+            density = 10,
+            friction = 0,
+            mask = 65535
+        },
+        gravitational_mass = 1,
+        isControlled = true,
+        shape = {
+            points = {
+                0, -25,
+                -25, 2,
+                -25, 25,
+                25, 2,
+                25, 25
+            },
+            type = 'polygon'
+        },
+        spritesheet = {
+            image = 'spaceship',
+            offset_x = 12.5,
+            scale_x = 2
+        }
+    }
+end

--- a/lib/tmx.lua
+++ b/lib/tmx.lua
@@ -313,16 +313,16 @@ local draw_tiles = function(layer, map)
   for i, tile in ipairs(layer.data) do
     -- Skip unset tiles
     if tile ~= 0 then
-        local tile_pos_x = map.tile_width * ((i - 1) % map.columns)
-        local tile_pos_y = map.tile_height * math.floor((i - 1) / map.columns)
-        local _, _, _, texture_height = map.quads[tile].quad:getViewport()
-        Love.graphics.draw(
-            map.quads[tile].image,
-            map.quads[tile].quad,
-            tile_pos_x,
-            -- Tiled counts image y position from bottom to top
-            tile_pos_y - texture_height + map.tile_height
-        )
+      local tile_pos_x = map.tile_width * ((i - 1) % map.columns)
+      local tile_pos_y = map.tile_height * math.floor((i - 1) / map.columns)
+      local _, _, _, texture_height = map.quads[tile].quad:getViewport()
+      Love.graphics.draw(
+        map.quads[tile].image,
+        map.quads[tile].quad,
+        tile_pos_x,
+        -- Tiled counts image y position from bottom to top
+        tile_pos_y - texture_height + map.tile_height
+      )
     end
   end
 end
@@ -391,7 +391,7 @@ end
 local load_fixtures = function(world, layer, layer_idx, entity_spawn_callback)
   local fixtures = {}
   for _, object in ipairs(layer.objects) do
-    if object.name and object.type == 'entity' then
+    if object.name then
       entity_spawn_callback(object, layer_idx)
     else
       local collision_fixture = spawn_fixture(world, object, layer_idx)

--- a/services/entity.lua
+++ b/services/entity.lua
@@ -8,7 +8,7 @@ local RegisterSprites = require 'systems/RegisterSprites'
 
 local entity_directory = 'entities'
 
-local get_entity_configs = function(directory)
+local get_entity_factories = function(directory)
     local entities = {}
     local file_list = Love.filesystem.getDirectoryItems(directory)
     for _, file_name in ipairs(file_list) do
@@ -22,7 +22,7 @@ local get_entity_configs = function(directory)
     return entities
 end
 
-local entity_configs = get_entity_configs(entity_directory)
+local entity_factories = get_entity_factories(entity_directory)
 local entities = {}
 
 -- Caveman way of getting the player
@@ -41,16 +41,17 @@ end
 -- }
 -- layer_index (number) what map layer to draw this in
 local spawn = function(object, layer_index)
-    local entity_config = entity_configs[object.name]
+    local entity_factory = entity_factories[object.name]
     assert(
-        entity_config ~= nil,
+        entity_factory ~= nil,
         'Map entity reference "' .. object.name .. '" not found.'
     )
 
-    -- Don't mutate the source config
-    local entity = Util.copy(entity_config)
-    -- Plovisionary table to write and track active inputs
-    entity.input = {}
+    -- Pass in the Tiled object to the factory so any spawn-point
+    -- specific properties can be extracted out as needed (Tiled's
+    -- "Custom Properties"), such as a custom radius for a planet.
+    local entity = entity_factory(object)
+
     -- Layer to draw player in. We could just get
     -- that information from the fixture collision
     -- group that was set but that collision group


### PR DESCRIPTION
Closes #16

TLDR Turns out I already took Custom Properties into consideration when I initially created the tmx parser. The custom props simply needed to be consumed during the entity spawning process. Converting the entity tables to factory functions achieves this. Try adding a planet to your map and setting a radius on it.

- Instantiate entities via factories to eliminate manual copying via
  traversal
- Allow factories to take in Tiled objects ("props") to override and
  define aspects from Tiled as needed