### PR TITLE
Add auto-linting via luacheck

### DIFF
--- a/.github/workflows/auto-lint.yml
+++ b/.github/workflows/auto-lint.yml
@@ -1,0 +1,12 @@
+name: Auto-lint
+on: [push, pull_request]
+
+jobs:
+  luacheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run luacheck
+      uses: judaew/luacheck-action@v0.2.1
+      with:
+        targets: "."


### PR DESCRIPTION
Github action will put a :x:  by all commits and pull requests that fail the linter check. You can run luacheck yourself locally by installing [luacheck](https://github.com/mpeterv/luacheck) and running `luacheck .` in the root of the project, or you can install a luacheck plugin for your editor to get real-time feedback which is much more useful in my opinion:
![Screenshot from 2022-01-30 21-13-10](https://user-images.githubusercontent.com/2344456/151730084-1c93d2a6-ffc0-46d4-9eb2-3842fbe8052d.png)